### PR TITLE
3.1.1 Release: Merge Hotfix branch into Master (#1747)

### DIFF
--- a/api/app/Helpers/TaxonomyHelper.php
+++ b/api/app/Helpers/TaxonomyHelper.php
@@ -126,7 +126,19 @@ class TaxonomyHelper {
 					//cycles through the final terms to evaluate and extract infraspecific data
 					while($sciStr = array_shift($sciNameArr)){
 						if($testArr = self::cleanInfra($sciStr)){
-							self::setInfraNode($sciStr, $sciNameArr, $retArr, $authorArr, $testArr['infra']);
+							if($sciNameArr){
+								$infraStr = array_shift($sciNameArr);
+								if(preg_match('/^[a-z]{3,}$/', $infraStr)){
+									$retArr['unitind3'] = $testArr['infra'];
+									$retArr['unitname3'] = $infraStr;
+									unset($authorArr);
+									$authorArr = array();
+								}
+								else{
+									$authorArr[] = $sciStr;
+									$authorArr[] = $infraStr;
+								}
+							}
 						}
 						elseif($kingdomName == 'Animalia' && !$retArr['unitname3'] && ($rankId == 230 || preg_match('/^[a-z]{3,}$/',$sciStr) || preg_match('/^[A-Z]{3,}$/',$sciStr))){
 							$retArr['unitind3'] = '';
@@ -244,22 +256,6 @@ class TaxonomyHelper {
 			$retArr['rankid'] = 230;
 		}
 		return $retArr;
-	}
-
-	private static function setInfraNode($sciStr, &$sciNameArr, &$retArr, &$authorArr, $rankTag){
-		if($sciNameArr){
-			$infraStr = array_shift($sciNameArr);
-			if(preg_match('/^[a-z]{3,}$/', $infraStr)){
-				$retArr['unitind3'] = $rankTag;
-				$retArr['unitname3'] = $infraStr;
-				unset($authorArr);
-				$authorArr = array();
-			}
-			else{
-				$authorArr[] = $sciStr;
-				$authorArr[] = $infraStr;
-			}
-		}
 	}
 
 	//Taxonomic indexing functions

--- a/classes/DwcArchiverOccurrence.php
+++ b/classes/DwcArchiverOccurrence.php
@@ -498,11 +498,9 @@ class DwcArchiverOccurrence extends Manager{
 	private function getAssociationJSON($occid) {
 
 		// Build SQL to find any associations for the occurrence record passed with occid
-		$sql = 'SELECT occid, occidAssociate, relationship, subType, identifier,' .
-			'basisOfRecord, resourceUrl, verbatimSciname, locationOnHost ' .
-			'FROM omoccurassociations ' .
-			'WHERE (occid = ' . $occid . ' OR occidAssociate = ' . $occid . ') ';
-
+		$sql = 'SELECT occid, associationType, occidAssociate, relationship, subType, identifier, basisOfRecord, resourceUrl, verbatimSciname, locationOnHost 
+			FROM omoccurassociations 
+			WHERE (occid = ' . $occid . ' OR occidAssociate = ' . $occid . ') ';
 		if ($rs = $this->conn->query($sql)) {
 
 			// No associations, so just return an empty string, and quit the function

--- a/classes/OccurrenceAssociations.php
+++ b/classes/OccurrenceAssociations.php
@@ -164,9 +164,9 @@ class OccurrenceAssociations extends Manager {
 
 	private function databaseAssocSpecies($assocArr, $occid){
 		if($assocArr){
-			$sql = 'INSERT INTO omoccurassociations(occid, verbatimsciname, relationship) VALUES';
+			$sql = 'INSERT INTO omoccurassociations(occid, associationType, verbatimsciname, relationship) VALUES';
 			foreach($assocArr as $aStr){
-				$sql .= '('.$occid.',"'.$this->conn->real_escape_string($aStr).'","associatedSpecies"), ';
+				$sql .= '('.$occid.', "observational", "'.$this->conn->real_escape_string($aStr).'","associatedSpecies"), ';
 			}
 			$sql = trim($sql,', ');
 			//echo $sql; exit;

--- a/classes/OccurrenceIndividual.php
+++ b/classes/OccurrenceIndividual.php
@@ -413,14 +413,24 @@ class OccurrenceIndividual extends Manager{
 			}
 		}
 		if($relOccidArr){
-			$sql = 'SELECT o.occid, o.sciname,
-				CONCAT_WS("-",IFNULL(o.institutioncode, c.institutioncode), IFNULL(o.collectioncode, c.collectioncode)) as collcode, IFNULL(o.catalogNumber, o.otherCatalogNumbers) as catnum
+			$sql = 'SELECT o.occid, o.sciname, IFNULL(o.institutioncode, c.institutioncode) as instCode, IFNULL(o.collectioncode, c.collectioncode) as collCode, o.catalogNumber, o.occurrenceID, o.recordID
 				FROM omoccurrences o INNER JOIN omcollections c ON o.collid = c.collid
 				WHERE o.occid IN(' . implode(',', array_keys($relOccidArr)) . ')';
 			$rs = $this->conn->query($sql);
 			while($r = $rs->fetch_object()){
 				foreach($relOccidArr[$r->occid] as $targetAssocID){
-					$this->occArr['relation'][$targetAssocID]['objectID'] = $r->collcode . ':' . $r->catnum;
+					$objectID = $r->catalogNumber;
+					if($objectID) {
+						if(strpos($objectID, $r->instCode) === false){
+							//Append institution and collection code to catalogNumber, but only if it is not already included 
+							$collCode = $r->instCode;
+							if($r->collCode) $collCode .= '-' . $r->collCode;
+							$objectID = $collCode . ':' . $r->catalogNumber;
+						}
+					}
+					elseif($r->occurrenceID) $objectID = $r->occurrenceID;
+					else $objectID = $r->recordID;
+					$this->occArr['relation'][$targetAssocID]['objectID'] = $objectID;
 					$this->occArr['relation'][$targetAssocID]['sciname'] = $r->sciname;
 				}
 			}
@@ -545,25 +555,15 @@ class OccurrenceIndividual extends Manager{
 				$displayStr = $this->occArr['catalognumber'];
 			}
 			elseif(strpos($iUrl,'--OTHERCATALOGNUMBERS--') !== false && $this->occArr['othercatalognumbers']){
-				if(substr($this->occArr['othercatalognumbers'],0,1) == '{'){
-					if($this->occArr['othercatalognumbers']){
-						foreach($this->occArr['othercatalognumbers'] as $idKey => $idArr){
-							if(!$displayStr || $idKey == 'NEON sampleID' || $idKey == 'NEON sampleCode (barcode)'){
-								$displayStr = $idArr[0];
-								if($idKey == 'NEON sampleCode (barcode)') $iUrl = str_replace('sampleTag','barcode',$iUrl);
-								$indUrl = str_replace('--OTHERCATALOGNUMBERS--',$idArr[0],$iUrl);
-								if($idKey == 'NEON sampleCode (barcode)') break;
-							}
-						}
+				foreach($this->occArr['othercatalognumbers'] as $idArr){
+					$tagName = $idArr['name'];
+					$idValue = $idArr['value'];
+					if(!$displayStr || $tagName == 'NEON sampleID' || $tagName == 'NEON sampleCode (barcode)'){
+						$displayStr = $tagName;
+						if($tagName == 'NEON sampleCode (barcode)') $iUrl = str_replace('sampleTag','barcode',$iUrl);
+						$indUrl = str_replace('--OTHERCATALOGNUMBERS--', $idValue, $iUrl);
+						if($tagName == 'NEON sampleCode (barcode)') break;
 					}
-				}
-				else{
-					$ocn = str_replace($this->occArr['othercatalognumbers'], ',', ';');
-					$ocnArr = explode(';',$ocn);
-					$ocnValue = trim(array_pop($ocnArr));
-					if(stripos($ocnValue,':')) $ocnValue = trim(array_pop(explode(':',$ocnValue)));
-					$indUrl = str_replace('--OTHERCATALOGNUMBERS--',$ocnValue,$iUrl);
-					$displayStr = $ocnValue;
 				}
 			}
 			elseif(strpos($iUrl,'--OCCURRENCEID--') !== false && $this->occArr['occurrenceid']){
@@ -1251,6 +1251,15 @@ class OccurrenceIndividual extends Manager{
 				}
 				$rsAssoc->free();
 				foreach($recArr['assoc'] as $pk => $secArr){
+					if(empty($secArr['associationType'])){
+						if(!empty($secArr['occidAssociate'])) $secArr['associationType'] = 'internalOccurrence';
+						elseif(!empty($secArr['resourceUrl'])){
+							if(!empty($secArr['verbatimSciname'])) $secArr['associationType'] = 'externalOccurrence';
+							else $secArr['associationType'] = 'resource';
+						}
+						elseif(!empty($secArr['verbatimSciname'])) $secArr['associationType'] = 'observational';
+						else $secArr['associationType'] = 'resource';
+					}
 					$sql1 = 'INSERT INTO omoccurassociations(';
 					$sql2 = 'VALUES(';
 					foreach($secArr as $f => $v){

--- a/classes/OccurrenceMapManager.php
+++ b/classes/OccurrenceMapManager.php
@@ -59,7 +59,7 @@ class OccurrenceMapManager extends OccurrenceManager {
 				'o.othercatalognumbers, c.institutioncode, c.collectioncode, c.CollectionName '.
 				'FROM omoccurrences o INNER JOIN omcollections c ON o.collid = c.collid ';
 
-			$this->sqlWhere .= 'AND ts.taxauthid = 1 ';
+			$this->sqlWhere .= 'AND (ts.taxauthid = 1 OR ts.taxauthid IS NULL) ';
 
 			$sql .= $this->getTableJoins($this->sqlWhere);
 
@@ -68,7 +68,6 @@ class OccurrenceMapManager extends OccurrenceManager {
 			if(is_numeric($start) && $limit){
 				$sql .= "LIMIT ".$start.",".$limit;
 			}
-			//echo '//SQL: ' . $sql;
 			$result = $this->conn->query($sql);
 			$color = 'e69e67';
 			$occidArr = array();

--- a/classes/OmAssociations.php
+++ b/classes/OmAssociations.php
@@ -77,13 +77,13 @@ class OmAssociations extends Manager{
 			$rs = $this->conn->query($sql);
 			while($r = $rs->fetch_object()){
 				$prefix = '';
-				if(strpos($r->catalogNumber, $r->instCode) === false){
+				if($r->catalogNumber && strpos($r->catalogNumber, $r->instCode) === false){
 					$prefix = $r->instCode;
 					if($r->collCode) $prefix .= '-' . $r->collCode;
 					$prefix .= ':';
 				}
 				foreach($relOccidArr[$r->occid] as $targetAssocID){
-					$retArr[$targetAssocID]['object-catalogNumber'] = $prefix . $r->catalogNumber;
+					$retArr[$targetAssocID]['object-catalogNumber'] = $prefix . ($r->catalogNumber ?? 'not defined');
 					$retArr[$targetAssocID]['verbatimSciname'] = $r->sciname;
 				}
 			}

--- a/classes/OmDeterminations.php
+++ b/classes/OmDeterminations.php
@@ -13,8 +13,16 @@ class OmDeterminations extends Manager{
 
 	public function __construct($conn){
 		parent::__construct(null, 'write', $conn);
+		/*
+		 $this->fieldMap = array('identifiedBy' => 's', 'identifiedByAgentID' => 'i', 'identifiedByID' => 's', 'dateIdentified' => 's', 'dateIdentifiedInterpreted' => 's',
+		 'higherClassification' => 's', 'family' => 's', 'sciname' => 's', 'verbatimIdentification' => 's', 'scientificNameAuthorship' => 's', 'tidInterpreted' => 'i',
+		 'identificationUncertain' => 'i', 'identificationQualifier' => 's', 'genus' => 's', 'specificEpithet' => 's', 'verbatimTaxonRank' => 's', 'taxonRank' => 's',
+		 'infraSpecificEpithet' => 's', 'isCurrent' => 'i', 'printQueue' => 'i', 'appliedStatus' => 'i', 'securityStatus' => 'i', 'securityStatusReason' => 's',
+		 'detType' => 's', 'identificationReferences' => 's', 'identificationRemarks' => 's', 'taxonRemarks' => 's', 'identificationVerificationStatus' => 's',
+		 'taxonConceptID' => 's', 'sourceIdentifier' => 's', 'sortSequence' => 'i', 'recordID' => 's', 'createdUid' => 'i', 'modifiedUid' => 'i', 'dateLastModified' => 's');
+		 */
 		$this->schemaMap = array('identifiedBy' => 's', 'dateIdentified' => 's', 'higherClassification' => 's', 'family' => 's', 'sciname' => 's', 'verbatimIdentification' => 's',
-			'scientificNameAuthorship' => 's', 'identificationUncertain' => 'i', 'identificationQualifier' => 's', 'isCurrent' => 'i', 'printQueue' => 'i', 'appliedStatus' => 'i',
+			'scientificNameAuthorship' => 's', 'identificationQualifier' => 's', 'isCurrent' => 'i', 'printQueue' => 'i', 'appliedStatus' => 'i',
 			'securityStatus' => 'i', 'securityStatusReason' => 's', 'detType' => 's', 'identificationReferences' => 's', 'identificationRemarks' => 's', 'taxonRemarks' => 's',
 			'identificationVerificationStatus' => 's', 'taxonConceptID' => 's', 'sourceIdentifier' => 's', 'sortSequence' => 'i');
 	}

--- a/classes/SpecUploadBase.php
+++ b/classes/SpecUploadBase.php
@@ -1960,6 +1960,7 @@ class SpecUploadBase extends SpecUpload{
 				unset($recMap['taxonrank']);
 				unset($recMap['infraspecificepithet']);
 				//Try to get author, if it's not there
+				/*
 				if(!array_key_exists('scientificnameauthorship',$recMap) || !$recMap['scientificnameauthorship']){
 					//Parse scientific name to see if it has author imbedded
 					$parsedArr = OccurrenceUtilities::parseScientificName($recMap['sciname'],$this->conn);
@@ -1969,6 +1970,7 @@ class SpecUploadBase extends SpecUpload{
 						$recMap['sciname'] = trim($parsedArr['unitname1'].' '.$parsedArr['unitname2'].' '.$parsedArr['unitind3'].' '.$parsedArr['unitname3']);
 					}
 				}
+				*/
 				if(!isset($recMap['sciname']) || !$recMap['sciname']) return false;
 
 				if(!isset($recMap['identifiedby'])) $recMap['identifiedby'] = '';
@@ -2540,10 +2542,7 @@ class SpecUploadBase extends SpecUpload{
 					}
 				}
 				else{
-					if(mb_detect_encoding($inStr,'UTF-8,ISO-8859-1',true) == 'ISO-8859-1'){
-						$retStr = utf8_encode($inStr);
-						//$retStr = iconv("ISO-8859-1//TRANSLIT","UTF-8",$inStr);
-					}
+					$retStr = mb_convert_encoding($inStr, 'UTF-8', mb_detect_encoding($inStr));
 				}
 			}
 			elseif($this->targetCharset == "ISO-8859-1"){

--- a/classes/TaxonomyEditorManager.php
+++ b/classes/TaxonomyEditorManager.php
@@ -592,7 +592,7 @@ class TaxonomyEditorManager extends Manager{
 				$sqlEnumTree = 'INSERT INTO taxaenumtree(tid,parenttid,taxauthid) '.
 					'SELECT '.$tid.' as tid, parenttid, taxauthid FROM taxaenumtree WHERE tid = '.$parTid;
 				if($this->conn->query($sqlEnumTree)){
-					$sqlEnumTree2 = 'INSERT INTO taxaenumtree(tid,parenttid,taxauthid) '.
+					$sqlEnumTree2 = 'INSERT IGNORE INTO taxaenumtree(tid,parenttid,taxauthid) '.
 						'VALUES ('.$tid.','.$parTid.','.$this->taxAuthId.')';
 					if(!$this->conn->query($sqlEnumTree2)){
 						echo (isset($this->langArr['WARNING_TAXAENUMTREE2'])?$this->langArr['WARNING_TAXAENUMTREE2']:'WARNING: Taxon loaded into taxa, but failed to populate taxaenumtree(2)').': '.$this->conn->error;

--- a/classes/TaxonomyUpload.php
+++ b/classes/TaxonomyUpload.php
@@ -955,17 +955,19 @@ class TaxonomyUpload{
 		$sourceArr = array();
 		if(($fh = fopen($this->uploadTargetPath.$this->uploadFileName,'r')) !== FALSE){
 			$headerArr = fgetcsv($fh);
-			if(substr($headerArr[0], 0, 3) == chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'))){
-				//Remove UTF-8 BOM
-				$headerArr[0] = trim(substr($headerArr[0], 3), ' "');
-			}
-			foreach($headerArr as $field){
-				$fieldStr = trim($field);
-				if($fieldStr){
-					$sourceArr[] = $fieldStr;
+			if($headerArr){
+				if(substr($headerArr[0], 0, 3) == chr(hexdec('EF')).chr(hexdec('BB')).chr(hexdec('BF'))){
+					//Remove UTF-8 BOM
+					$headerArr[0] = trim(substr($headerArr[0], 3), ' "');
 				}
-				else{
-					break;
+				foreach($headerArr as $field){
+					$fieldStr = trim($field);
+					if($fieldStr){
+						$sourceArr[] = $fieldStr;
+					}
+					else{
+						break;
+					}
 				}
 			}
 		}

--- a/classes/TaxonomyUtilities.php
+++ b/classes/TaxonomyUtilities.php
@@ -42,7 +42,7 @@ class TaxonomyUtilities {
 			}
 			//Remove extra spaces
 			$inStr = preg_replace('/\s\s+/',' ',$inStr);
-
+			if(!$inStr) return $retArr;
 			$sciNameArr = explode(' ',trim($inStr));
 			$okToCloseConn = true;
 			if($conn !== null) $okToCloseConn = false;
@@ -127,7 +127,19 @@ class TaxonomyUtilities {
 					//cycles through the final terms to evaluate and extract infraspecific data
 					while($sciStr = array_shift($sciNameArr)){
 						if($testArr = self::cleanInfra($sciStr)){
-							self::setInfraNode($sciStr, $sciNameArr, $retArr, $authorArr, $testArr['infra']);
+							if($sciNameArr){
+								$infraStr = array_shift($sciNameArr);
+								if(preg_match('/^[a-z]{3,}$/', $infraStr)){
+									$retArr['unitind3'] = $testArr['infra'];
+									$retArr['unitname3'] = $infraStr;
+									unset($authorArr);
+									$authorArr = array();
+								}
+								else{
+									$authorArr[] = $sciStr;
+									$authorArr[] = $infraStr;
+								}
+							}
 						}
 						elseif($kingdomName == 'Animalia' && !$retArr['unitname3'] && ($rankId == 230 || preg_match('/^[a-z]{3,}$/',$sciStr) || preg_match('/^[A-Z]{3,}$/',$sciStr))){
 							$retArr['unitind3'] = '';
@@ -245,22 +257,6 @@ class TaxonomyUtilities {
 			$retArr['rankid'] = 230;
 		}
 		return $retArr;
-	}
-
-	private static function setInfraNode($sciStr, &$sciNameArr, &$retArr, &$authorArr, $rankTag){
-		if($sciNameArr){
-			$infraStr = array_shift($sciNameArr);
-			if(preg_match('/^[a-z]{3,}$/', $infraStr)){
-				$retArr['unitind3'] = $rankTag;
-				$retArr['unitname3'] = $infraStr;
-				unset($authorArr);
-				$authorArr = array();
-			}
-			else{
-				$authorArr[] = $sciStr;
-				$authorArr[] = $infraStr;
-			}
-		}
 	}
 
 	//Taxonomic indexing functions

--- a/collections/admin/specuploadmap.php
+++ b/collections/admin/specuploadmap.php
@@ -587,9 +587,9 @@ include($SERVER_ROOT.'/includes/header.php');
 								<?php
 							}
 							?>
-							<button type="submit" name="action" value="Automap Fields" ><?php echo (isset($LANG['AUTOMAP']) ? $LANG['AUTOMAP'] : 'Automap Fields'); ?></button>
-							<button type="submit" name="action" value="Verify Mapping" ><?php echo (isset($LANG['VER_MAPPING']) ? $LANG['VER_MAPPING'] : 'Verify Mapping'); ?></button>
-							<button type="submit" name="action" value="saveMapping" onclick="return verifySaveMapping(this.form)" ><?php echo (isset($LANG['SAVE_MAP']) ? $LANG['SAVE_MAP'] : 'Save Mapping'); ?></button>
+							<button class="bottom-breathing-room-rel-sm" type="submit" name="action" value="Automap Fields" ><?php echo (isset($LANG['AUTOMAP']) ? $LANG['AUTOMAP'] : 'Automap Fields'); ?></button>
+							<button class="bottom-breathing-room-rel-sm" type="submit" name="action" value="Verify Mapping" ><?php echo (isset($LANG['VER_MAPPING']) ? $LANG['VER_MAPPING'] : 'Verify Mapping'); ?></button>
+							<button class="bottom-breathing-room-rel-sm" type="submit" name="action" value="saveMapping" onclick="return verifySaveMapping(this.form)" ><?php echo (isset($LANG['SAVE_MAP']) ? $LANG['SAVE_MAP'] : 'Save Mapping'); ?></button>
 							<span id="newProfileNameDiv" style="margin-left:15px;color:red;display:none">
 								<?php echo (isset($LANG['NEW_PROF_TITLE']) ? $LANG['NEW_PROF_TITLE'] : 'New profile title'); ?>:
 								<input type="text" name="profiletitle" style="width:300px" value="<?php echo $duManager->getTitle().'-'.date('Y-m-d'); ?>" />

--- a/collections/editor/includes/resourcetab.php
+++ b/collections/editor/includes/resourcetab.php
@@ -364,12 +364,12 @@ $dupClusterArr = $dupManager->getClusterArr($occid);
 					<div class="assoc-div">
 						<div><label><?= $LANG['ASSOCIATION_TYPE'] ?>:</label>
 							<?= $assocUnit['associationType'] ?>
-							<form action="resourcehandler.php" method="post" style="display:inline">
+							<form action="resourcehandler.php" method="post" style="display:inline; margin: 0px; padding: 0px">
 								<input name="occid" type="hidden" value="<?php echo $occid; ?>">
 								<input name="collid" type="hidden" value="<?php echo $collid; ?>">
 								<input name="occindex" type="hidden" value="<?php echo $occIndex; ?>">
 								<input name="delassocid" type="hidden" value="<?php echo $assocID; ?>">
-								<input class="icon-img" type="image" src="../../images/del.png">
+								<input class="icon-img" type="image" src="../../images/del.png" style="margin: 0px">
 							</form>
 							<a href="#" onclick="toggle('edit-assoc-div-<?= $assocID ?>')"><img class="icon-img" src="../../images/edit.png"></a>
 						</div>

--- a/collections/editor/skeletalsubmit.php
+++ b/collections/editor/skeletalsubmit.php
@@ -86,7 +86,7 @@ if($collid){
 					</div>
  				</div>
 				<form id="defaultform" name="defaultform" action="skeletalsubmit.php" method="post" autocomplete="off" onsubmit="return submitDefaultForm(this)">
-					<div id="optiondiv" style="display:none;position:absolute;background-color:white;">
+					<div id="optiondiv" style="display:none;position:absolute;background-color:white; z-index: 1;">
 						<fieldset style="margin-top: -10px;padding-top:5px">
 							<legend><?php echo $LANG['OPTIONS']; ?></legend>
 							<div style="float:right;"><a href="#" onclick="hideOptions()" style="color:red" ><?php echo $LANG['X_CLOSE']; ?></a></div>

--- a/collections/individual/index.php
+++ b/collections/individual/index.php
@@ -309,11 +309,17 @@ $traitArr = $indManager->getTraitArr();
 		.smaller-header {
 			font-size: 2rem;
 		}
-		<?php if($shouldUseMinimalMapHeader){ ?>
+		#exsiccati-div{ clear: both; }
+		#rights-div{ clear: both; }
+		<?php
+		if($shouldUseMinimalMapHeader){
+			?>
 			.minimal-header-margin{
 			   margin-top: 6rem;
 			}
-		<?php } ?>
+			<?php
+		}
+		?>
 		</style>
 </head>
 <body>
@@ -435,7 +441,7 @@ $traitArr = $indManager->getTraitArr();
 										$relID = $assocArr['objectID'];
 										$relUrl = $assocArr['resourceurl'];
 										if(!$relUrl && $assocArr['occidassoc']) $relUrl = $GLOBALS['CLIENT_ROOT'].'/collections/individual/index.php?occid='.$assocArr['occidassoc'];
-										if($relUrl) $relID = '<a href="' . $relUrl . '">' . $relID . '</a>';
+										if($relUrl) $relID = '<a href="' . $relUrl . '" target="_blank">' . ($relID ? $relID : $relUrl) . '</a>';
 										if($relID) echo $relID;
 										if($assocArr['sciname']) echo ' [' . $assocArr['sciname'] . ']';
 										echo '</div>';

--- a/collections/search/index.php
+++ b/collections/search/index.php
@@ -217,7 +217,8 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 						<div id="search-form-latlong">
 							<div id="bounding-box-form">
 								<h1 class="bounding-box-form__header"><?php echo $LANG['BOUNDING_BOX'] ?></h1>
-								<button onclick="openCoordAid('rectangle');return false;"><?php echo $LANG['SELECT_IN_MAP'] ?></button>
+
+								<button type="button" onclick="openCoordAid('rectangle');"><?php echo $LANG['SELECT_IN_MAP'] ?></button>
 								<div class="input-text-container">
 										<label for="upperlat" class="input-text--outlined">
 											<span class="screen-reader-only"><?php echo $LANG['UPPER_LATITUDE'] ?></span>
@@ -286,7 +287,7 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 							</div>
 							<div id="polygon-form">
 								<h1 class="bounding-box-form__header"><?php echo $LANG['POLYGON_WKT_FOOTPRINT'] ?></h1>
-								<button onclick="openCoordAid('polygon');return false;"><?php echo $LANG['SELECT_MAP_POLYGON'] ?></button>
+								<button type="button" onclick="openCoordAid('polygon')"><?php echo $LANG['SELECT_MAP_POLYGON'] ?></button>
 								<div class="text-area-container">
 									<label for="footprintwkt" class="text-area--outlined">
 										<span class="screen-reader-only"><?php echo $LANG['POLYGON'] ?></span>
@@ -298,7 +299,7 @@ $obsArr = (isset($collList['obs'])?$collList['obs']:null);
 							</div>
 							<div id="point-radius-form">
 								<h1 class="bounding-box-form__header"><?php echo $LANG['POINT_RADIUS'] ?></h1>
-								<button onclick="openCoordAid('circle');return false;"><?php echo $LANG['SELECT_MAP_PR'] ?></button>
+								<button type="button" onclick="openCoordAid('circle');"><?php echo $LANG['SELECT_MAP_PR'] ?></button>
 								<div class="input-text-container">
 									<label for="pointlat" class="input-text--outlined">
 										<span class="screen-reader-only"><?php echo $LANG['POINT_LATITUDE'] ?></span>

--- a/config/symbbase.php
+++ b/config/symbbase.php
@@ -2,7 +2,7 @@
 header('X-Frame-Options: DENY');
 header('Cache-control: private'); // IE 6 FIX
 date_default_timezone_set('America/Phoenix');
-$CODE_VERSION = '3.1';
+$CODE_VERSION = '3.1.1';
 
 set_include_path(get_include_path() . PATH_SEPARATOR . $SERVER_ROOT . PATH_SEPARATOR . $SERVER_ROOT.'/config/' . PATH_SEPARATOR . $SERVER_ROOT.'/classes/');
 
@@ -74,6 +74,6 @@ if($LANG_TAG != 'en' && !in_array($LANG_TAG, $AVAILABLE_LANGS)) $LANG_TAG = 'en'
 //Sanitization
 const HTML_SPECIAL_CHARS_FLAGS = ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE;
 
-$CSS_VERSION = '15';
+$CSS_VERSION = '16';
 
 ?>

--- a/css/symbiota/main.css
+++ b/css/symbiota/main.css
@@ -670,11 +670,11 @@ table.styledtable tr.alt td {
 
 /* JQUERY UI modifications */
 .ui-tabs-panel {
-  font-size: 1rem;
+  font-size: 1.2rem;
 }
 
 .ui-tabs-tab {
-  font-size: 1rem;
+  font-size: 1.2rem;
 }
 
 .ui-autocomplete {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,59 +3,65 @@
 All notable changes to this project will be documented in this file.
 
 ## [3.1] - 2024-08-29
-### New Feature 
-* 508 Accessibility features
-* Extended occurrence data upload module. Supports import and linking occurrence to: associated occurrences, identifications/annotations, image links, material samples, and reference links
-* LeafLet JavaScript added as an open source mapping option  
-* MediaWiki parser for mapping and integration of Flora of North American descriptions into taxon profile pages  
-* Occurrence associations management tools
-* Occurrence distribution static map thumbnail generator 
-* Public occurrence search form - new streamline version (via NEON support)
-* Responsive design framework
-* Specimen image batch tagging tool
-   
-### Changed
-* Bionomia badges and GBIF citation counts/links added to collection profile pages
-* Glossary improvements including ability to link terms into identification keys 
-* Identification Key user interface improved to including display of taxa as thumbnails
-* Significant extension of Spanish and French translation files, including refactor of how header, footer, and index language are integrated
-* Support for new Occurrence fields: waterBody, continent, islandGroup, island, countryCode, locationID, eventID, vitality, eventDateEnd 
-* Restructure css files, including removal of deprecated and redundant stylings
-* Taxon harvesting tool reconfigured to import directly from ChecklistBank API rather than Catalog of Life 
-* Security patches 
-** Update TinyMCE JS library 
-** Update jQuery JS libraries 
-** Cross-site scripting (XSS) protections - Improve sanitation of input variables to protect against 
-** SQL Injection protections - Improved prepared statements support 
 
+### New Feature
+
+- 508 Accessibility features
+- Extended occurrence data upload module. Supports import and linking occurrence to: associated occurrences, identifications/annotations, image links, material samples, and reference links
+- LeafLet JavaScript added as an open source mapping option
+- MediaWiki parser for mapping and integration of Flora of North American descriptions into taxon profile pages
+- Occurrence associations management tools
+- Occurrence distribution static map thumbnail generator
+- Public occurrence search form - new streamline version (via NEON support), including trait-based and material-sample-based search for portals with those features enabled
+- Responsive design framework
+- Specimen image batch tagging tool
+- New quicksearch box in the collection profile
+
+### Changed
+
+- Bionomia badges and GBIF citation counts/links added to collection profile pages
+- Glossary improvements including ability to link terms into identification keys
+- Identification Key user interface improved to including display of taxa as thumbnails
+- Significant extension of Spanish and French translation files, including refactor of how header, footer, and index language are integrated
+- Support for new Occurrence fields: waterBody, continent, islandGroup, island, countryCode, locationID, eventID, vitality, eventDateEnd
+- Restructure css files, including removal of deprecated and redundant stylings
+- Taxon harvesting tool reconfigured to import directly from ChecklistBank API rather than Catalog of Life
+- Security patches
+  ** Update TinyMCE JS library
+  ** Update jQuery JS libraries
+  ** Cross-site scripting (XSS) protections - Improve sanitation of input variables to protect against
+  ** SQL Injection protections - Improved prepared statements support
 
 ## [3.0] - 2022-01-14
+
 ### Added
-* Integrate additional identifiers table into occurrence management and publishing tools (table: omoccuridentifiers) 
-* Integrate Material Sample module into occurrence editor, public display, import, and export tools 
+
+- Integrate additional identifiers table into occurrence management and publishing tools (table: omoccuridentifiers)
+- Integrate Material Sample module into occurrence editor, public display, import, and export tools
 
 ### Changed
-* Add coordinate verification tool to editor using GBIF reverse geocode REST service
+
+- Add coordinate verification tool to editor using GBIF reverse geocode REST service
 
 ## [1.2.0] - 2022-01-13
 
 ### Added
-* Occurrence dataset management toolkits (available via My Profile => Occurrence Management) (2020-12-23)   
-* New module for creating custom Specimen Labels formats linked to portal, collection, or user
-* Option to link multiple ResponsibleParty associations to a collection (e.g. collection contacts) (2020-12-21)
-* Option to associate multiple reference links to a collection (2020-12-21)
-* Support tables for defining Controlled Vocabularies 
-* Paleo data management module including support for: editor, import, export, public display
-* Establishing and managing relationships between occurrences (e.g. parasite/host) 
-* Occurrence Traits management tools 
+
+- Occurrence dataset management toolkits (available via My Profile => Occurrence Management) (2020-12-23)
+- New module for creating custom Specimen Labels formats linked to portal, collection, or user
+- Option to link multiple ResponsibleParty associations to a collection (e.g. collection contacts) (2020-12-21)
+- Option to associate multiple reference links to a collection (2020-12-21)
+- Support tables for defining Controlled Vocabularies
+- Paleo data management module including support for: editor, import, export, public display
+- Establishing and managing relationships between occurrences (e.g. parasite/host)
+- Occurrence Traits management tools
 
 ### Changed
 
 ## [1.1.0] - 2015-12-29
 
 ### Added
+
 ### Changed
-
-
 
 [![version](https://img.shields.io/badge/Symbiota-v1.2.0.1.202201-blue.svg)](https://semver.org)

--- a/taxa/profile/tpeditor.php
+++ b/taxa/profile/tpeditor.php
@@ -169,11 +169,11 @@ if($isEditor && $action){
 		#redirectedfrom{ font-size:1rem; margin-top:5px; margin-left:10px; font-weight:bold; }
 		#taxonDiv{ font-size:1.125rem; margin-top:15px; margin-left:10px; }
 		#taxonDiv a{ color:#990000; font-weight: bold; font-style: italic; }
-		#taxonDiv img{ border: 0px; margin: 0px; height: 15px; }
 		#familyDiv{ margin-left:20px; margin-top:0.25em; }
 		.tox-dialog{ min-height: 400px }
 		input{ margin:3px; border:inset; }
 		hr{ margin:30px 0px; }
+		.icon-img{ border: 0px; height: 1.2em; }
 	</style>
 </head>
 <body>
@@ -195,7 +195,7 @@ if($isEditor && $action){
 			if($isEditor){
 				if($tEditor->isForwarded()) echo '<div id="redirectedfrom">' . $LANG['REDIRECTED_FROM'] . ': <i>' . $tEditor->getSubmittedValue('sciname') . '</i></div>';
 				echo '<div id="taxonDiv"><a href="../index.php?taxon=' . htmlspecialchars($tEditor->getTid(), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . '">' . $LANG['VIEW_PUBLIC_TAXON'] . '</a> ';
-				if($tEditor->getRankId() > 140) echo "&nbsp;<a href='tpeditor.php?tid=" . htmlspecialchars($tEditor->getParentTid(), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . "'><img src='../../images/toparent.png' style='width:1.3em' title='" . htmlspecialchars($LANG['GO_TO_PARENT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . "' /></a>";
+				if($tEditor->getRankId() > 140) echo "&nbsp;<a href='tpeditor.php?tid=" . htmlspecialchars($tEditor->getParentTid(), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . "'><img class='icon-img' src='../../images/toparent.png' title='" . htmlspecialchars($LANG['GO_TO_PARENT'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE) . "' /></a>";
 				echo "</div>\n";
 				if($tEditor->getFamily()) echo '<div id="familyDiv"><b>' . $LANG['FAMILY'] . ':</b> ' . $tEditor->getFamily() . '</div>' . "\n";
 				if($statusStr) echo '<div style="margin:15px;font-weight:bold;font-size:120%;color:' . (stripos($statusStr,'error') !== false?'red':'green') .';">' . $statusStr . '</div>';
@@ -218,7 +218,7 @@ if($isEditor && $action){
 							<div style="margin:10px 0px" title="<?php echo $LANG['ADD_COMMON_NAME']; ?>">
 								<b><?php echo ($vernacularList ? $LANG['COMMON_NAMES'] : $LANG['NO_COMMON_NAMES']); ?></b>
 								<a href="#" onclick="toggle('addvern');return false;">
-									<img style="border:0px;width:1.3em;" src="../../images/add.png"/>
+									<img class="icon-img" src="../../images/add.png"/>
 								</a>
 							</div>
 							<div id="addvern" class="addvern" style="display:<?php echo ($vernacularList?'none':'block'); ?>;">
@@ -271,7 +271,7 @@ if($isEditor && $action){
 											<div style="margin-left:10px;" title="<?php echo $LANG['EDIT_COMMON_NAME']; ?>">
 												<b><?php echo $vernArr['vernname']; ?></b>
 												<a href="#" onclick="toggle('vid-<?php echo $vid; ?>');return false;">
-													<img style="border:0px;width:1.2em;" src="../../images/edit.png" />
+													<img class="icon-img" src="../../images/edit.png" />
 												</a>
 											</div>
 											<form name="updatevern" action="tpeditor.php" method="post" style="margin:15px;clear:both">
@@ -348,7 +348,7 @@ if($isEditor && $action){
 							if($synonymArr = $tEditor->getSynonym()){
 								?>
 								<div style="float:right;" title="<?php echo $LANG['EDIT_SYN_ORDER']; ?>">
-									<a href="#"  onclick="toggle('synsort');return false;"><img style="border:0px;width:1.2em;" src="../../images/edit.png"/></a>
+									<a href="#"  onclick="toggle('synsort');return false;"><img class="icon-img" src="../../images/edit.png"/></a>
 								</div>
 								<div style="font-weight:bold;margin-left:15px;">
 									<ul>


### PR DESCRIPTION
* Occurrence Mapping: Adjust SQL to relax enforcement of link to taxon thesaurus, thus to include records with coordinates but lacking thesaurus relationship 
* Styling: Various styling, spacing, and display adjustments 
* Occurrence search: add type attribute to buttons to avoid defaulting as submit buttons 
* Occurrence Profile: Fix error triggered when otherCatalogNumbers are used to create backlink to original snapshot record within external institution web resource
* Occurrence editing functions   -- Fix fatal error triggered by cloning an occurrence record with the create association option selected -- Fix fatal error triggered when quick association feature is activated within occurrence editor -- Fix fatal error when deleting an occurrence when the occurrence was previously deleted (e.g. record already in omoccurarchive) -- Adjust occurrence restore option to dynamically determine associationType when restoring a record that was deleted prior to this field being added as a required input -- If resource association does not have an objectID, use url as the display text
* Taxonomy editor: bug fix triggered by adding a child directly to the root node of the thesaurus (e.g. kingdom)
* Scientific name parsing utility functions: Integrate cleanInfra function directly into code. It served no purpose being separate, and was also causing a bug where parent authors were being incorrectly merged with insfraspecific authors